### PR TITLE
enhance get_terraform_outputs function

### DIFF
--- a/Projects/Week3/AzureHighlightProcessorTerraform/src/update_env.py
+++ b/Projects/Week3/AzureHighlightProcessorTerraform/src/update_env.py
@@ -16,17 +16,15 @@ import json
 import subprocess
 import os
 
-def get_terraform_outputs(terraform_dir):
+def get_terraform_outputs(terraform_dir=None):
     """
-    Executes 'terraform output -json' and returns the parsed JSON outputs.
+    Executes 'terraform output -json' in the specified directory and returns the parsed JSON outputs.
     """
     try:
         # Change to the Terraform directory
         original_dir = os.getcwd()
         if terraform_dir:
             os.chdir(terraform_dir)
-        else:
-            terraform_dir = os.getcwd()
         
         # Run the terraform command to get outputs as JSON.
         result = subprocess.check_output(["terraform", "output", "-json"])

--- a/Projects/Week3/AzureHighlightProcessorTerraform/src/update_env.py
+++ b/Projects/Week3/AzureHighlightProcessorTerraform/src/update_env.py
@@ -16,17 +16,31 @@ import json
 import subprocess
 import os
 
-def get_terraform_outputs():
+def get_terraform_outputs(terraform_dir):
     """
     Executes 'terraform output -json' and returns the parsed JSON outputs.
     """
     try:
+        # Change to the Terraform directory
+        original_dir = os.getcwd()
+        if terraform_dir:
+            os.chdir(terraform_dir)
+        else:
+            terraform_dir = os.getcwd()
+        
         # Run the terraform command to get outputs as JSON.
         result = subprocess.check_output(["terraform", "output", "-json"])
         outputs = json.loads(result.decode())
+        
+        # Change back to the original directory
+        os.chdir(original_dir)
+
         return outputs
     except subprocess.CalledProcessError as e:
         print(f"Error retrieving Terraform outputs: {e}")
+        return None
+    except Exception as e:
+        print(f"An error occurred: {e}")
         return None
 
 def update_env_file(outputs):
@@ -71,6 +85,6 @@ def update_env_file(outputs):
     print(f"  AZURE_BLOB_CONTAINER_NAME={container_name}")
 
 if __name__ == "__main__":
-    outputs = get_terraform_outputs()
+    outputs = get_terraform_outputs('./terraform')
     if outputs:
         update_env_file(outputs)


### PR DESCRIPTION
This function now takes a terraform_dir argument, which is the path to the directory containing your Terraform files. It changes the working directory to terraform_dir before running the `terraform output -json `command and then changes back to the original directory after retrieving the outputs.